### PR TITLE
feature: Make API version configurable

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -6,9 +6,10 @@ LOG = logging.getLogger(__name__)
 BASE_URL = 'http://{0}:1925/{1}/{2}'
 TIMEOUT = 5.0
 CONNFAILCOUNT = 5
+DEFAULT_API_VERSION = 1
 
 class PhilipsTV(object):
-    def __init__(self, host, api_version="1"):
+    def __init__(self, host, api_version=DEFAULT_API_VERSION):
         self._host = host
         self._api_version = api_version
         self._connfail = 0

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -3,13 +3,14 @@ import json
 import logging
 
 LOG = logging.getLogger(__name__)
-BASE_URL = 'http://{0}:1925/1/{1}'
+BASE_URL = 'http://{0}:1925/{1}/{2}'
 TIMEOUT = 5.0
 CONNFAILCOUNT = 5
 
 class PhilipsTV(object):
-    def __init__(self, host):
+    def __init__(self, host, api_version="1"):
         self._host = host
+        self._api_version = api_version
         self._connfail = 0
         self.on = None
         self.name = None
@@ -28,7 +29,7 @@ class PhilipsTV(object):
                 LOG.debug("Connfail: %i", self._connfail)
                 self._connfail -= 1
                 return None
-            resp = requests.get(BASE_URL.format(self._host, path), timeout=TIMEOUT)
+            resp = requests.get(BASE_URL.format(self._host, self.api_version, path), timeout=TIMEOUT)
             self.on = True
             return json.loads(resp.text)
         except requests.exceptions.RequestException as err:
@@ -43,7 +44,7 @@ class PhilipsTV(object):
                 LOG.debug("Connfail: %i", self._connfail)
                 self._connfail -= 1
                 return False
-            resp = requests.post(BASE_URL.format(self._host, path), data=json.dumps(data), timeout=TIMEOUT)
+            resp = requests.post(BASE_URL.format(self._host, self.api_version, path), data=json.dumps(data), timeout=TIMEOUT)
             self.on = True
             if resp.status_code == 200:
                 return True


### PR DESCRIPTION
I'm sorry, I never written a single line of Python nor I know how to write HA components...

I think the code changes are fine, I'm not sure if I need to do something more to read the `api_version` configuration option from the `configuration.yaml`

This should be good enough to add support for v5 API and start experimenting with it and see what else needs to be fixed.

The usage would be:

```yaml
media_player:
  - platform: philips_js
    host: 10.0.0.2
    api_version: 5
```    

I guess once (if) this gets merged I'll need to update the HA component as well to make it accept this new parameter.