### PR TITLE
Restore support for sources on v1 api

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -170,7 +170,7 @@ class PhilipsTV(object):
             if self._postReq('sources/current', {'id': id}):
                 self.source_id = id
 
-    def setVolume(self, level):
+    def setVolume(self, level, muted):
         if level:
             if self.min_volume != 0 or not self.max_volume:
                 self.getAudiodata()
@@ -184,8 +184,9 @@ class PhilipsTV(object):
             if targetlevel < self.min_volume + 1 or targetlevel > self.max_volume:
                 LOG.warning("Level not in range (%i - %i)" % (self.min_volume + 1, self.max_volume))
                 return
-            self._postReq('audio/volume', {'current': targetlevel, 'muted': False})
+            self._postReq('audio/volume', {'current': targetlevel, 'muted': muted})
             self.volume = targetlevel
+            self.muted = muted
 
     def sendKey(self, key):
         self._postReq('input/key', {'key': key})

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -24,6 +24,7 @@ class PhilipsTV(object):
         self.source_id = None
         self.channels = None
         self.channel_id = None
+        self.session = requests.Session()
 
     def _getReq(self, path):
         try:
@@ -31,11 +32,11 @@ class PhilipsTV(object):
                 LOG.debug("Connfail: %i", self._connfail)
                 self._connfail -= 1
                 return None
-            resp = requests.get(BASE_URL.format(self._host, self.api_version, path), timeout=TIMEOUT)
-            if resp.status_code != 200:
-                return None
-            self.on = True
-            return json.loads(resp.text)
+            with self.session.get(BASE_URL.format(self._host, self.api_version, path), timeout=TIMEOUT) as resp:
+                if resp.status_code != 200:
+                    return None
+                self.on = True
+                return json.loads(resp.text)
         except requests.exceptions.RequestException as err:
             LOG.debug("Exception: %s", str(err))
             self._connfail = CONNFAILCOUNT
@@ -48,12 +49,12 @@ class PhilipsTV(object):
                 LOG.debug("Connfail: %i", self._connfail)
                 self._connfail -= 1
                 return False
-            resp = requests.post(BASE_URL.format(self._host, self.api_version, path), data=json.dumps(data), timeout=TIMEOUT)
-            self.on = True
-            if resp.status_code == 200:
-                return True
-            else:
-                return False
+            with self.session.post(BASE_URL.format(self._host, self.api_version, path), data=json.dumps(data), timeout=TIMEOUT) as resp:
+                self.on = True
+                if resp.status_code == 200:
+                    return True
+                else:
+                    return False
         except requests.exceptions.RequestException as err:
             LOG.debug("Exception: %s", str(err))
             self._connfail = CONNFAILCOUNT

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -170,7 +170,7 @@ class PhilipsTV(object):
             if self._postReq('sources/current', {'id': id}):
                 self.source_id = id
 
-    def setVolume(self, level, muted):
+    def setVolume(self, level, muted = False):
         if level:
             if self.min_volume != 0 or not self.max_volume:
                 self.getAudiodata()

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -61,7 +61,6 @@ class PhilipsTV(object):
             return False
 
     def update(self):
-        self.getName()
         self.getSystem()
         self.getAudiodata()
         self.getSources()
@@ -69,16 +68,11 @@ class PhilipsTV(object):
         self.getChannels()
         self.getChannelId()
 
-    def getName(self):
-        r = self._getReq('system/name')
-        if r:
-            self.name = r['name']
-
     def getSystem(self):
-        if self.api_version >= '6':
-            r = self._getReq('system')
-            if r:
-                self.system = r
+        r = self._getReq('system')
+        if r:
+            self.system = r
+            self.name = r['name']
 
     def getAudiodata(self):
         audiodata = self._getReq('audio/volume')

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -115,6 +115,8 @@ class PhilipsTV(object):
                 self.channel_id = r['id']
 
     def getChannelName(self, ccid):
+        if not self.channels:
+            return None
         return self.channels.get(ccid, dict()).get('name', None)
 
     def setChannel(self, ccid):
@@ -154,6 +156,8 @@ class PhilipsTV(object):
                 self.source_id = None
 
     def getSourceName(self, srcid):
+        if not self.sources:
+            return None
         if self.api_version < 5:
             return self.sources.get(srcid, dict()).get('name', None)
 

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -185,7 +185,7 @@ class PhilipsTV(object):
                 LOG.warning("Level not in range (%i - %i)" % (self.min_volume + 1, self.max_volume))
                 return
             self._postReq('audio/volume', {'current': targetlevel, 'muted': muted})
-            self.volume = targetlevel
+            self.volume = level
             self.muted = muted
 
     def sendKey(self, key):

--- a/haphilipsjs/__main__.py
+++ b/haphilipsjs/__main__.py
@@ -14,8 +14,8 @@ if __name__ == '__main__':
         action="store_true",
         default=False,
     )
-    parser.add_argument("-i", "--host", dest="host")
-    parser.add_argument("-a", "--api", dest="api")
+    parser.add_argument("-i", "--host", dest="host", required=True)
+    parser.add_argument("-a", "--api", dest="api", required=True)
     args = parser.parse_args()
     logging.basicConfig(level=args.debug and logging.DEBUG or logging.INFO)
     haphilipsjs.TIMEOUT = 60.0

--- a/haphilipsjs/__main__.py
+++ b/haphilipsjs/__main__.py
@@ -1,0 +1,45 @@
+if __name__ == '__main__':
+    import argparse
+    import logging
+    import haphilipsjs
+
+    logger = logging.getLogger(__name__)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-d",
+        "--debug",
+        help="Debug output",
+        dest="debug",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument("-i", "--host", dest="host")
+    parser.add_argument("-a", "--api", dest="api")
+    args = parser.parse_args()
+    logging.basicConfig(level=args.debug and logging.DEBUG or logging.INFO)
+    haphilipsjs.TIMEOUT = 60.0
+    tv = haphilipsjs.PhilipsTV(args.host, int(args.api))
+    tv.update()
+    tv.getChannelId()
+    tv.getChannels()
+
+    # Simulating homeassistant/components/media_player/philips_js.py
+    logger.info('Source: %s', tv.getSourceName(tv.source_id))
+    if tv.sources:
+        logger.info(
+            'Sources: %si...',
+            ', '.join([
+                tv.getSourceName(srcid)
+                for srcid in tv.sources
+            ])
+        )
+    logger.info('Channel: %s', tv.getChannelName(tv.channel_id))
+    if tv.channels:
+        logger.info(
+            'Channels: %s...',
+            ', '.join([
+                tv.getChannelName(ccid)
+                for ccid in list(tv.channels.keys())[:10]
+            ])
+        )


### PR DESCRIPTION
This moves data request on v5/6 api into the channel functions instead
which seems more in line with what they actually do. Once
https://github.com/home-assistant/home-assistant/pull/15941 is
merged the source list should just return a single entry for
v5 api (or be corrected to actually grab list of sources)