### PR TITLE
getChannelLists is working in API version 5.

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -114,15 +114,12 @@ class PhilipsTV(object):
             self.channel_id = id
 
     def getChannelLists(self):
-        if self.api_version >= '6':
-            r = self._getReq('channeldb/tv')
-            if r:
-                # could be alltv and allsat
-                return [l['id'] for l in r.get('channelLists', [])]
-            else:
-                return []
+        r = self._getReq('channeldb/tv')
+        if r:
+            # could be alltv and allsat
+            return [l['id'] for l in r.get('channelLists', [])]
         else:
-            return ['alltv']
+            return []
 
     def getSources(self):
         self.sources = []


### PR DESCRIPTION
TVs with API version 5 can break if only sat is used and getChannelLists is working with API level 5. This is tested with my API-Level 5 TV.