### PR TITLE
add try and except to get channels

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -33,6 +33,8 @@ class PhilipsTV(object):
                 if resp.status_code != 200:
                     return None
                 return resp.json()
+        except requests.exceptions.Timeout:
+            return None
         except requests.exceptions.RequestException as err:
             raise ConnectionFailure(str(err)) from err
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 PACKAGE_NAME = 'ha-philipsjs'
 HERE = os.path.abspath(os.path.dirname(__file__))
-VERSION = '0.0.8'
+VERSION = '0.0.9'
 
 PACKAGES = find_packages(exclude=['tests', 'tests.*', 'dist', 'ccu', 'build'])
 


### PR DESCRIPTION
Hi!

My Philips tv doesn't hold any channels because we use it a glorified monitor. This patch adds a try and except to the getchannels function to allow for it to generate a exception and return a empty channels db. 