### PR TITLE
Add recordings to notifyChange event and monitor

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -1450,6 +1450,8 @@ class PhilipsTV(object):
                 "menuitems/settings/version": {"version": self.settings_version}
             }
         }
+        if (self.api_version == 6) and self.json_feature_supported("recordings", "List"):
+            data["notification"].update({"recordings/list": self.recordings_list})
 
         timeout_ctx = httpx.Timeout(timeout=TIMEOUT, connect=TIMEOUT_CONNECT, read=timeout)
         try:
@@ -1484,6 +1486,12 @@ class PhilipsTV(object):
 
             if "menuitems/settings/version" in result:
                 self.settings_version = result["menuitems/settings/version"]["version"]
+
+            if "recordings/list" in result:
+                #TV just updates the recording 'version' and doesn't sent the actual 'recordings'
+                if self.recordings_list != None:
+                    if self.recordings_list["version"] != result["recordings/list"]["version"]:
+                        self.recordings_list = self.getRecordings()
 
             return True
 

--- a/haphilipsjs/__main__.py
+++ b/haphilipsjs/__main__.py
@@ -56,6 +56,20 @@ async def monitor_run(stdscr, tv: PhilipsTV):
         for idx, channel  in enumerate(tv.channels_current):
             stdscr.addstr(1+idx, 70, channel.get("name", channel.get("ccid")))
 
+        #Recordings just known working with API level 6 currently
+        if tv.api_version_detected == 6:
+            stdscr.addstr(0, 90, "Recordings")
+            if tv.recordings_list != None:
+                for idx, rec  in enumerate(tv.recordings_list["recordings"]):
+                    title = rec.get("RecName")
+                    type = rec.get("RecordingType")
+                    
+                    if type == "RECORDING_NEW":
+                        title = "*NEW* " + title
+                    elif type == "RECORDING_ONGOING":
+                        title = "*REC* " + title
+
+                    stdscr.addstr(1+idx, 90, title)
 
         def print_pixels(side, offset_y, offset_x):
             stdscr.addstr(offset_y, offset_x, "{}".format(side))


### PR DESCRIPTION
This pull request adds the recording list functionality for API-Level 6 to the notifyChange eventing system.
It was suggested in https://github.com/danielperna84/ha-philipsjs/pull/30#pullrequestreview-1403149400.

I have some connection losses to my TV, but as I never used this functionality before, I'm unsure if this happens more often.
This needs some more investigation.
(My productive HomeAssistant instance is connecting to the TV in parallel as well...)
