### PR TITLE
Update getSystem to try both http and https

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -748,7 +748,9 @@ class PhilipsTV(object):
     async def getSystem(self):
         # Newest TV software requires https for system-info. Therefore we will try both protocols.
         protocols = ["http", "https"]
-        orig_protocol = self.protocol
+
+        if protocols[0] != self.protocol:
+            protocols = reversed(protocols)
         
         for prot in protocols:
             r = cast(Optional[SystemType], await self.getReq("system", protocol=prot))
@@ -759,7 +761,6 @@ class PhilipsTV(object):
             else:
                 self.system = {}
                 self.name = None
-        self.protocol = orig_protocol
         return r
 
     async def getAudiodata(self):

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -556,17 +556,16 @@ class PhilipsTV(object):
         if protocol is None:
             protocol = self.protocol
 
-        if self.protocol == "https":
+        if protocol == "https":
             port = HTTPS_PORT
         else:
             port = HTTP_PORT
 
         return f"{protocol}://{self._host}:{port}/{self.api_version}/{path}"
 
-    async def getReq(self, path) -> Optional[Dict]:
-
+    async def getReq(self, path, protocol = None) -> Optional[Dict]:
         try:
-            resp = await self.session.get(self._url(path))
+            resp = await self.session.get(self._url(path, protocol = protocol))
             if resp.status_code == 401:
                 raise AutenticationFailure("Authenticaion failed to device")
 
@@ -752,8 +751,7 @@ class PhilipsTV(object):
         orig_protocol = self.protocol
         
         for prot in protocols:
-            self.protocol = prot
-            r = cast(Optional[SystemType], await self.getReq("system"))
+            r = cast(Optional[SystemType], await self.getReq("system", protocol=prot))
             if r:
                 self.system = self._decodeSystem(r)
                 self.name = r.get("name")

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -747,13 +747,21 @@ class PhilipsTV(object):
         return cast(SystemType, result)
 
     async def getSystem(self):
-        r = cast(Optional[SystemType], await self.getReq("system"))
-        if r:
-            self.system = self._decodeSystem(r)
-            self.name = r.get("name")
-        else:
-            self.system = {}
-            self.name = None
+        # Newest TV software requires https for system-info. Therefore we will try both protocols.
+        protocols = ["http", "https"]
+        orig_protocol = self.protocol
+        
+        for prot in protocols:
+            self.protocol = prot
+            r = cast(Optional[SystemType], await self.getReq("system"))
+            if r:
+                self.system = self._decodeSystem(r)
+                self.name = r.get("name")
+                return r
+            else:
+                self.system = {}
+                self.name = None
+        self.protocol = orig_protocol
         return r
 
     async def getAudiodata(self):

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -75,6 +75,9 @@ async def client_mock(param: Param):
             respx.get(f"{param.base}/system").respond(
                 json=cast(Dict, SYSTEM_ANDROID_ENCRYPTED)
             )
+            respx.get("http://127.0.0.1:1925/6/system").respond(
+                json={}
+            )
             respx.get(f"{param.base}/channeldb/tv").respond(
                 json=cast(Dict, CHANNELDB_TV_ANDROID)
             )


### PR DESCRIPTION
The newest TV software (API 6 at least) just allows https connections to get system information.