### PR TITLE
Correct pair request information for SAPHI tv's

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -345,7 +345,7 @@ class PhilipsTV(object):
                 self.system.get("featuring", {})
                 .get("systemfeatures", {})
                 .get("secured_transport")
-                == "true"
+                in ("true", True)
             )
         else:
             return None

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -641,7 +641,18 @@ class PhilipsTV(object):
 
         state = {"device": device}
 
-        data = {"scope": ["read", "write", "control"], "device": device}
+        data = {
+            "access": {
+                "scope": ["read", "write", "control"]
+            },
+            "device": device
+        }
+
+        if self.system:
+            featuring = self.system.get("featuring", None)
+            if featuring:
+                data["access"]["featuring"] = featuring
+
 
         LOG.debug("pair/request request: %s", data)
         resp = await self.session.post(self._url("pair/request"), json=data, auth=None)

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -9,7 +9,7 @@ from base64 import b64decode, b64encode
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.padding import PKCS7
-from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.hashes import SHA1
 from cryptography.hazmat.primitives.hmac import HMAC
 
 from .typing import (
@@ -70,7 +70,7 @@ MAXIMUM_ITEMS_IN_REQUEST = 50
 
 def hmac_signature(key: bytes, timestamp: str, data: str):
     """Calculate a timestamped signature."""
-    hmac = HMAC(key, SHA256())
+    hmac = HMAC(key, SHA1())
     hmac.update(timestamp.encode("utf-8"))
     hmac.update(data.encode("utf-8"))
     return b64encode(hmac.finalize()).decode("utf-8")

--- a/haphilipsjs/__main__.py
+++ b/haphilipsjs/__main__.py
@@ -297,7 +297,7 @@ async def run(args, parser, tv: PhilipsTV):
             "ha-philipsjs", "ha-philipsjs", platform.node(), platform.system(), "native"
         )
 
-        pin = input("Please enter pin displayed on scree")
+        pin = input("Please enter pin displayed on screen: ")
 
         res = await tv.pairGrant(state, pin)
 

--- a/haphilipsjs/data/v6.py
+++ b/haphilipsjs/data/v6.py
@@ -640,6 +640,39 @@ CONTEXT: ContextType = {
     "level3": "NA",
 }
 
+PAIR_REQUEST_DEVICE = {
+  "id": "aaabbbcccdddeee",
+  "device_name": "Android device",
+  "device_os": "Android 12",
+  "app_id": "com.tpvision.philipstvapp2",
+  "app_name": "Philips TV Remote",
+  "type": "native"
+}
+
+PAIR_REQUEST_SAPHI = {
+  "device": PAIR_REQUEST_DEVICE,
+  "access": {
+    "featuring": SYSTEM_SAPHI["featuring"],
+    "scope": ["read", "write", "control"]
+  }
+}
+
+PAIR_REQUEST_ANDROID = {
+  "device": PAIR_REQUEST_DEVICE,
+  "access": {
+    "featuring": SYSTEM_ANDROID["featuring"],
+    "scope": ["read", "write", "control"]
+  }
+}
+
+PAIR_RESPONSE = {
+	"error_id": "SUCCESS",
+	"error_text": "Authorization required",
+	"auth_key": "ccddeeffgghh",
+	"timestamp": 1128,
+	"timeout": 30
+}
+
 MENUITEMS_SETTINGS_STRUCTURE: MenuItemsSettingsStructure = {
   "node": {
     "node_id": 2131230753,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,13 @@
+
+from haphilipsjs import AUTH_SHARED_KEY, hmac_signature
+import pytest
+
+@pytest.mark.parametrize(
+    ("timestamp", "auth_key", "pin", "auth_signature"),
+    [
+        (1128, "um27pghe7wyo0ysu", "0667", "rdPzC+bdWQHQMcwe3X+LddeG/tA=")
+    ]
+)
+async def test_hmac(timestamp, auth_key, pin, auth_signature):
+    
+    assert hmac_signature(AUTH_SHARED_KEY, str(timestamp), pin) == auth_signature


### PR DESCRIPTION
1. Our scope field was added in a wrong location.
2. We used the wrong SHA algorithm (android TV's ignore value)

Related to: https://github.com/home-assistant/core/issues/100682
