### PR TITLE
Switch to 3 keep alive connections

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -210,7 +210,8 @@ class PhilipsTV(object):
         password=None,
         verify=False,
         auth_shared_key=None,
-        system = None
+        system = None,
+        limits = None,
     ):
         self._host = host
         self._connfail = 0
@@ -257,7 +258,8 @@ class PhilipsTV(object):
             self.protocol = "http"
 
         timeout = httpx.Timeout(timeout=TIMEOUT, connect=TIMEOUT_CONNECT)
-        limits = httpx.Limits(max_keepalive_connections=0, max_connections=3)
+        if limits is None:
+            limits = httpx.Limits(max_keepalive_connections=3, max_connections=3)
         self.session = httpx.AsyncClient(limits=limits, timeout=timeout, verify=False)
         self.session.headers["Accept"] = "application/json"
 


### PR DESCRIPTION
There are indications that this may avoid backlogging connections on certain TV's. I am not sure why it was dis-allowed a while back. Could have been older tv's if so let's find out.