### PR TITLE
Add retry on protocol errors

### DIFF
--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -359,6 +359,15 @@ async def test_send_key_off(client_mock, param: Param):
         await client_mock.sendKey("Standby")
 
 
+async def test_send_key_retry(client_mock, param: Param):
+    route = respx.post(f"{param.base}/input/key").mock(side_effect=httpx.RemoteProtocolError)
+
+    with pytest.raises(haphilipsjs.ProtocolFailure):
+        await client_mock.sendKey("Standby")
+
+    assert route.call_count == 2
+
+
 async def test_ambilight_mode(client_mock, param):
     await client_mock.getSystem()
 


### PR DESCRIPTION
Some tv's disconnect lingering connections at write time, leading to an exception. Retry the request once in those cases.