### PR TITLE
fix: correct invalid json on TPN256E

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -111,6 +111,7 @@ def decode_xtv_json(text: str):
         data = json.loads(text)
     except json.decoder.JSONDecodeError:
         LOG.debug("Invalid json received, trying adjusted version")
+        text = text.replace('"channelList": { "id": "version", "" }', '"channelList": { "id": "all", "version": "" }')
         text = text.replace("{,", "{")
         text = text.replace(",}", "}")
         while (p := text.find(",,")) >= 0:

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -588,6 +588,12 @@ async def test_buggy_json():
     assert haphilipsjs.decode_xtv_json('{,"a":{}}') == {"a": {}}
     assert haphilipsjs.decode_xtv_json('{"a":{},}') == {"a": {}}
     assert haphilipsjs.decode_xtv_json('{"a":{},,,"b":{}}') == {"a": {}, "b": {}}
+    
+    # Invalid data seen on TPN256E
+    assert haphilipsjs.decode_xtv_json('{ "channelList": { "id": "version", "" } }') == {
+        "channelList": { "id": "all", "version": "" }
+    }
+
     with pytest.raises(haphilipsjs.NoneJsonData):
         haphilipsjs.decode_xtv_json("Plain text data")
 


### PR DESCRIPTION
Some Titan based TV's give junk on channel list info. Correct the invalid json so we can parse the data.

Fixes #44 