### PR TITLE
Add favorite list write support (modifyfavourite + PUT favoriteLists)

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -635,6 +635,23 @@ class PhilipsTV(object):
             LOG.debug("Read time out on postReq", exc_info=True)
             return None
 
+    @handle_httpx_exceptions
+    async def putReq(self, path: str, data: Any, timeout=None, protocol=None) -> Optional[Dict]:
+        try:
+            resp = await self.session.put(self._url(path, protocol), json=data, timeout=timeout)
+            if resp.status_code == 401:
+                raise AutenticationFailure("Authenticaion failed to device")
+
+            if resp.status_code == 200:
+                LOG.debug("Put succeded: %s -> %s", data, resp.text)
+                return decode_xtv_response(resp)
+
+            LOG.debug("Put failed: %s -> %s", data, resp.text)
+            return None
+        except httpx.ReadTimeout:
+            LOG.debug("Read time out on putReq", exc_info=True)
+            return None
+
     async def pairRequest(
         self,
         app_id: str,
@@ -909,6 +926,48 @@ class PhilipsTV(object):
                 return r["channels"]
             else:
                 return None
+
+    async def setFavoriteList(self, list_id: str, channels: List[int]):
+        """Replace the channel list of a favorite list via PUT.
+
+        TV must be watching a channel (not on home screen) or a 503 is returned.
+        list_id: "1" through "8"
+        channels: ordered list of ccid integers
+        """
+        if self.api_version >= 6:
+            if self.json_feature_supported("editfavorites"):
+                data = {"channels": channels}
+                if await self.putReq(f"channeldb/tv/favoriteLists/{list_id}", data) is not None:
+                    return True
+        return False
+
+    async def modifyFavoriteList(
+        self,
+        list_id: str,
+        add: Optional[List[int]] = None,
+        remove: Optional[List[int]] = None,
+        name: Optional[str] = None,
+    ):
+        """Add/remove channels or rename a favorite list via POST.
+
+        TV must be watching a channel (not on home screen) or a 503 is returned.
+        list_id: "1" through "8"
+        add: list of ccid integers to add
+        remove: list of ccid integers to remove
+        name: optional new display name for the list
+        """
+        if self.api_version >= 6:
+            if self.json_feature_supported("editfavorites"):
+                data: Dict[str, Any] = {}
+                if add is not None:
+                    data["add"] = {"id": add}
+                if remove is not None:
+                    data["remove"] = {"id": remove}
+                if name is not None:
+                    data["name"] = name
+                if await self.postReq(f"channeldb/tv/modifyfavourite/{list_id}", data) is not None:
+                    return True
+        return False
 
     async def getChannelList(self, list_id: str):
         if self.api_version >= 5:

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -659,18 +659,20 @@ async def test_pair_request(client_mock: haphilipsjs.PhilipsTV, param: Param):
 
 
 async def test_set_favorite_list(client_mock, param: Param):
+    await client_mock.update()
     respx.put(f"{param.base}/channeldb/tv/favoriteLists/1").respond(json={})
 
-    result = await client_mock.setFavoriteList("1", [{"ccid": 1649}])
+    result = await client_mock.setFavoriteList("1", [1649])
 
     assert result is True
     assert respx.calls[-1].request.url == f"{param.base}/channeldb/tv/favoriteLists/1"
     assert json.loads(respx.calls[-1].request.content) == {
-        "channels": [{"ccid": 1649}],
+        "channels": [1649],
     }
 
 
 async def test_set_favorite_list_fail(client_mock, param: Param):
+    await client_mock.update()
     respx.put(f"{param.base}/channeldb/tv/favoriteLists/1").respond(status_code=503)
 
     result = await client_mock.setFavoriteList("1", [1649])
@@ -678,6 +680,7 @@ async def test_set_favorite_list_fail(client_mock, param: Param):
 
 
 async def test_modify_favorite_list_add(client_mock, param: Param):
+    await client_mock.update()
     respx.post(f"{param.base}/channeldb/tv/modifyfavourite/1").respond(json={})
 
     result = await client_mock.modifyFavoriteList("1", add=[1649])
@@ -690,6 +693,7 @@ async def test_modify_favorite_list_add(client_mock, param: Param):
 
 
 async def test_modify_favorite_list_remove(client_mock, param: Param):
+    await client_mock.update()
     respx.post(f"{param.base}/channeldb/tv/modifyfavourite/1").respond(json={})
 
     result = await client_mock.modifyFavoriteList("1", remove=[1648])
@@ -702,18 +706,20 @@ async def test_modify_favorite_list_remove(client_mock, param: Param):
 
 
 async def test_modify_favorite_list_rename(client_mock, param: Param):
-    respx.post(f"{param.base}/channeldb/tv/modifyfavorite/1").respond(json={})
+    await client_mock.update()
+    respx.post(f"{param.base}/channeldb/tv/modifyfavourite/1").respond(json={})
 
     result = await client_mock.modifyFavoriteList("1", name="My Channels")
 
     assert result is True
-    assert respx.calls[-1].request.url == f"{param.base}/channeldb/tv/modifyfavorite/1"
+    assert respx.calls[-1].request.url == f"{param.base}/channeldb/tv/modifyfavourite/1"
     assert json.loads(respx.calls[-1].request.content) == {
         "name": "My Channels",
     }
 
 
 async def test_modify_favorite_list_combined(client_mock, param: Param):
+    await client_mock.update()
     respx.post(f"{param.base}/channeldb/tv/modifyfavourite/1").respond(json={})
 
     result = await client_mock.modifyFavoriteList("1", add=[1649], remove=[1648], name="Favorites")
@@ -728,6 +734,7 @@ async def test_modify_favorite_list_combined(client_mock, param: Param):
 
 
 async def test_modify_favorite_list_fail(client_mock, param: Param):
+    await client_mock.update()
     respx.post(f"{param.base}/channeldb/tv/modifyfavourite/1").respond(status_code=503)
 
     result = await client_mock.modifyFavoriteList("1", add=[1649])

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -656,3 +656,79 @@ async def test_pair_request(client_mock: haphilipsjs.PhilipsTV, param: Param):
             "auth_key": PAIR_RESPONSE["auth_key"],
             "timestamp": PAIR_RESPONSE["timestamp"],
         }
+
+
+async def test_set_favorite_list(client_mock, param: Param):
+    respx.put(f"{param.base}/channeldb/tv/favoriteLists/1").respond(json={})
+
+    result = await client_mock.setFavoriteList("1", [{"ccid": 1649}])
+
+    assert result is True
+    assert respx.calls[-1].request.url == f"{param.base}/channeldb/tv/favoriteLists/1"
+    assert json.loads(respx.calls[-1].request.content) == {
+        "channels": [{"ccid": 1649}],
+    }
+
+
+async def test_set_favorite_list_fail(client_mock, param: Param):
+    respx.put(f"{param.base}/channeldb/tv/favoriteLists/1").respond(status_code=503)
+
+    result = await client_mock.setFavoriteList("1", [1649])
+    assert result is False
+
+
+async def test_modify_favorite_list_add(client_mock, param: Param):
+    respx.post(f"{param.base}/channeldb/tv/modifyfavourite/1").respond(json={})
+
+    result = await client_mock.modifyFavoriteList("1", add=[1649])
+
+    assert result is True
+    assert respx.calls[-1].request.url == f"{param.base}/channeldb/tv/modifyfavourite/1"
+    assert json.loads(respx.calls[-1].request.content) == {
+        "add": {"id": [1649]},
+    }
+
+
+async def test_modify_favorite_list_remove(client_mock, param: Param):
+    respx.post(f"{param.base}/channeldb/tv/modifyfavourite/1").respond(json={})
+
+    result = await client_mock.modifyFavoriteList("1", remove=[1648])
+
+    assert result is True
+    assert respx.calls[-1].request.url == f"{param.base}/channeldb/tv/modifyfavourite/1"
+    assert json.loads(respx.calls[-1].request.content) == {
+        "remove": {"id": [1648]},
+    }
+
+
+async def test_modify_favorite_list_rename(client_mock, param: Param):
+    respx.post(f"{param.base}/channeldb/tv/modifyfavorite/1").respond(json={})
+
+    result = await client_mock.modifyFavoriteList("1", name="My Channels")
+
+    assert result is True
+    assert respx.calls[-1].request.url == f"{param.base}/channeldb/tv/modifyfavorite/1"
+    assert json.loads(respx.calls[-1].request.content) == {
+        "name": "My Channels",
+    }
+
+
+async def test_modify_favorite_list_combined(client_mock, param: Param):
+    respx.post(f"{param.base}/channeldb/tv/modifyfavourite/1").respond(json={})
+
+    result = await client_mock.modifyFavoriteList("1", add=[1649], remove=[1648], name="Favorites")
+
+    assert result is True
+    assert respx.calls[-1].request.url == f"{param.base}/channeldb/tv/modifyfavourite/1"
+    assert json.loads(respx.calls[-1].request.content) == {
+        "add": {"id": [1649]},
+        "remove": {"id": [1648]},
+        "name": "Favorites",
+    }
+
+
+async def test_modify_favorite_list_fail(client_mock, param: Param):
+    respx.post(f"{param.base}/channeldb/tv/modifyfavourite/1").respond(status_code=503)
+
+    result = await client_mock.modifyFavoriteList("1", add=[1649])
+    assert result is False


### PR DESCRIPTION
Turns out Philips TVs have had write endpoints for favorites all along — they
just never documented them. We found them by pulling xtv.apk off a TV via ADB
and decompiling it with jadx.

Two new methods:

- `setFavoriteList(list_id, channels)` — replaces the entire favorites list (PUT)
- `modifyFavoriteList(list_id, add, remove, name)` — add/remove individual channels (POST)

The fun part: POST to `/favoriteLists/{id}` returns 405 — you have to use PUT.
And the add/remove endpoint is at a completely different path (`/modifyfavourite/{id}`)
with a nested JSON format (`{"add": {"id": [...]}}` not `{"add": [...]}`).

Also, writes only work while the TV is on a channel. If it's on the home screen
you get 503, because `FavouritesManager.isValidContext()` checks for WatchTv/
WatchSatellite/WatchVirtualSource context. That's why everyone assumed it was
read-only.

Both methods check `api_version >= 6` and `json_feature_supported("editfavorites")`
before hitting the API, same pattern as the rest of the codebase.

Tested on a 2019 Philips Android TV (MSAF_2019_P, API v6.4.0).

See also: eslavnov/pylips#126 for full endpoint documentation.