### PR TITLE
Cache and skip endpoints that return 403/404

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union, cast, overload, Iterable, TypeVar
+from typing import Any, Dict, List, Optional, Set, Tuple, TypeVar, Union, cast, overload, Iterable, TypeVar
 import httpx
 import logging
 import json
@@ -277,6 +277,7 @@ class PhilipsTV(object):
         self.recordings_list: Optional[RecordingsListed] = None
         self.huelamp_power: Optional[str] = None
         self.powerstate = None
+        self._dead_endpoints: Set[str] = set()
         if auth_shared_key:
             self.auth_shared_key = auth_shared_key
         else:
@@ -597,10 +598,18 @@ class PhilipsTV(object):
 
     @handle_httpx_exceptions
     async def getReq(self, path, protocol = None) -> Optional[Dict]:
+        if path in self._dead_endpoints:
+            return None
+
         resp = await self.session.get(self._url(path, protocol = protocol))
 
         if resp.status_code == 401:
             raise AutenticationFailure("Authenticaion failed to device")
+
+        if resp.status_code in (403, 404):
+            LOG.info("Marking endpoint %s as dead after %d response", path, resp.status_code)
+            self._dead_endpoints.add(path)
+            return None
 
         if resp.status_code != 200:
             LOG.debug("Get failed: %s -> %d %s", path, resp.status_code, resp.text)

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -368,6 +368,22 @@ async def test_send_key_retry(client_mock, param: Param):
     assert route.call_count == 2
 
 
+@pytest.mark.parametrize("status_code", [403, 404])
+async def test_dead_endpoint_skip(client_mock, param: Param, status_code):
+    """Endpoints returning 403/404 are cached as dead and not re-requested."""
+    path = "recordings/list"
+    route = respx.get(f"{param.base}/{path}").respond(status_code=status_code)
+
+    assert path not in client_mock._dead_endpoints
+    assert await client_mock.getReq(path) is None
+    assert path in client_mock._dead_endpoints
+    assert route.call_count == 1
+
+    # Second call should short-circuit without hitting the network.
+    assert await client_mock.getReq(path) is None
+    assert route.call_count == 1
+
+
 async def test_ambilight_mode(client_mock, param):
     await client_mock.getSystem()
 


### PR DESCRIPTION
On Philips API 6.x firmware (verified TPN248E and TPN256E, reported in home-assistant/core#156776), four endpoints called in every `update()` cycle return 403/404 and never recover within a session: `sources/current`, `applications/current`, `hue/lampPower`, `recordings/list`.

This patch caches paths on first 403/404 from `getReq` and short-circuits subsequent calls. No behavior change for callers — `getReq` was already returning `None` for these — but it cuts ~33% of per-cycle poll volume on affected firmwares and removes a chunk of background load that contributes to the HTTP-server wedges users hit in the linked issue.

Session-scoped, no TTL or re-probe. Test added covering 403 and 404 against both `android` and `saphi` param fixtures.
