### PR TITLE
Reset dead-endpoint cache on connection recovery

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -744,9 +744,19 @@ class PhilipsTV(object):
             LOG.info("Switching to api_version %d", api_version)
             self.api_version = api_version
 
+    def _reset_dead_endpoints(self) -> None:
+        """Drop the dead-endpoint cache, e.g. on TV reconnect."""
+        if self._dead_endpoints:
+            LOG.info(
+                "TV reconnecting; clearing %d dead endpoint(s)",
+                len(self._dead_endpoints),
+            )
+            self._dead_endpoints.clear()
+
     async def update(self):
         try:
             if not self.on:
+                self._reset_dead_endpoints()
                 await self.getSystem()
                 await self.setTransport(self.secured_transport)
                 await self.getSources()

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -384,6 +384,23 @@ async def test_dead_endpoint_skip(client_mock, param: Param, status_code):
     assert route.call_count == 1
 
 
+async def test_dead_endpoints_reset_on_off_to_on(client_mock, param: Param):
+    """update() clears the dead-endpoint cache on the off-to-on transition."""
+    assert await client_mock.update() is True
+    assert client_mock.on is True
+
+    respx.get(f"{param.base}/some/dead").respond(status_code=404)
+    assert await client_mock.getReq("some/dead") is None
+    assert "some/dead" in client_mock._dead_endpoints
+
+    # Simulate the TV becoming unreachable (a ConnectionFailure would normally
+    # cause this transition; we set it directly to keep the test focused).
+    client_mock.on = False
+
+    assert await client_mock.update() is True
+    assert "some/dead" not in client_mock._dead_endpoints
+
+
 async def test_ambilight_mode(client_mock, param):
     await client_mock.getSystem()
 


### PR DESCRIPTION
Clear `_dead_endpoints` on the off→on transition in `update()` via a small `_reset_dead_endpoints()` helper. A TV reboot or transient outage no longer leaves stale entries blocking valid responses after reconnection.

Suggested by @elupus in #48.