### PR TITLE
Honor IGNORED_JSON_RESPONSES in decode_xtv_json

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -103,6 +103,8 @@ def cbc_encode(key: bytes, data: str):
 
 
 def decode_xtv_json(text: str):
+    if text in IGNORED_JSON_RESPONSES:
+        return {}
     try:
         data = json.loads(text)
     except json.decoder.JSONDecodeError:


### PR DESCRIPTION
`decode_xtv_response` already short-circuits to `{}` for empty bodies and known-garbage responses like `"Context Service not started"` or `"}"` via `IGNORED_JSON_RESPONSES`. `decode_xtv_json` didn't, so calling it directly with those inputs raised `NoneJsonData`. That regressed `test_buggy_json`, which has been the only failing test in CI for a while.

Moving the check to `decode_xtv_json` makes both entry points handle these inputs uniformly. Two-line fix, existing test now passes.
