### PR TITLE
Make quirk_ambilight_mode_ignored workaround conditional

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -1135,15 +1135,6 @@ class PhilipsTV(object):
         data = await self.getReq("ambilight/mode")
         if data:
             self.ambilight_mode_raw = data["current"]
-
-            if self.quirk_ambilight_mode_ignored:
-                # we could probably disable quirk here
-                if data["current"] != "internal" and self.ambilight_mode_set:
-                    LOG.warning(
-                        "TV properly report ambilight mode, quirk should be disabled"
-                    )
-                    self.ambilight_mode_set = None
-
             return data["current"]
 
         else:
@@ -1157,13 +1148,15 @@ class PhilipsTV(object):
         if self.quirk_ambilight_mode_ignored:
             if mode == "internal":
                 self.ambilight_mode_set = None
-                if (
-                    await self.postReq(
-                        "ambilight/mode", {"current": "internal_invalid"}
-                    )
-                    is None
-                ):
-                    LOG.info("Ignoring error for workaround for ambilight mode")
+                check = await self.getReq("ambilight/mode") or {}
+                if check.get("current") != "internal":
+                    if (
+                        await self.postReq(
+                            "ambilight/mode", {"current": "internal_invalid"}
+                        )
+                        is None
+                    ):
+                        LOG.debug("Ignoring error for workaround for ambilight mode")
             else:
                 self.ambilight_mode_set = mode
 

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -390,20 +390,17 @@ async def test_ambilight_mode(client_mock, param):
     respx.post(f"{param.base}/ambilight/mode").respond(json={})
     await client_mock.setAmbilightMode("internal")
 
-    if client_mock.quirk_ambilight_mode_ignored:
-        assert respx.calls[-2].request.url == f"{param.base}/ambilight/mode"
-        assert json.loads(respx.calls[-2].request.content) == {
-            "current": "internal",
-        }
-        assert respx.calls[-1].request.url == f"{param.base}/ambilight/mode"
-        assert json.loads(respx.calls[-1].request.content) == {
-            "current": "internal_invalid",
-        }
-    else:
-        assert respx.calls[-1].request.url == f"{param.base}/ambilight/mode"
-        assert json.loads(respx.calls[-1].request.content) == {
-            "current": "internal",
-        }
+    # The fixture's GET /ambilight/mode returns {"current": "internal"}, so even
+    # on quirked devices the post-POST check sees the mode flipped cleanly and
+    # does NOT fire the internal_invalid workaround.
+    mode_posts = [
+        c for c in respx.calls
+        if c.request.method == "POST"
+        and str(c.request.url) == f"{param.base}/ambilight/mode"
+    ]
+    sent_bodies = [json.loads(c.request.content) for c in mode_posts]
+    assert {"current": "internal"} in sent_bodies
+    assert {"current": "internal_invalid"} not in sent_bodies
 
     assert await client_mock.getAmbilightMode()
     assert client_mock.ambilight_mode == "internal"
@@ -417,6 +414,32 @@ async def test_ambilight_mode(client_mock, param):
 
     assert await client_mock.setAmbilightMode("interal")
     assert await client_mock.getAmbilightMode()
+
+
+async def test_ambilight_mode_workaround_triggered(client_mock, param: Param):
+    """When the quirk is active and POST mode=internal does not actually flip
+    the mode (GET still reports the previous value), the library follows up
+    with mode=internal_invalid as a workaround."""
+    await client_mock.getSystem()
+
+    if not client_mock.quirk_ambilight_mode_ignored:
+        pytest.skip("Workaround only runs when quirk_ambilight_mode_ignored is True")
+
+    respx.post(f"{param.base}/ambilight/mode").respond(json={})
+    # Simulate the firmware-bug case: POST is silently rejected, GET reflects
+    # the unchanged mode.
+    respx.get(f"{param.base}/ambilight/mode").respond(json={"current": "lounge"})
+
+    await client_mock.setAmbilightMode("internal")
+
+    mode_posts = [
+        c for c in respx.calls
+        if c.request.method == "POST"
+        and str(c.request.url) == f"{param.base}/ambilight/mode"
+    ]
+    sent_bodies = [json.loads(c.request.content) for c in mode_posts]
+    assert {"current": "internal"} in sent_bodies
+    assert {"current": "internal_invalid"} in sent_bodies
 
 
 async def test_ambilight_power(client_mock, param):


### PR DESCRIPTION
The runtime check in `getAmbilightMode` previously emitted WARNING `TV properly report ambilight mode, quirk should be disabled` and cleared `self.ambilight_mode_set`. Clearing that field silently disables the workaround for the rest of the session, since the `ambilight_mode` property uses it to mask `ambilight_mode_raw` while the quirk is active. The check itself was based on the wrong signal: any non-internal mode round-trip would fire it, even though that proves nothing about whether `setAmbilightMode("internal")` (the actual broken path) works.

This patch removes that block entirely and moves the discrimination into `setAmbilightMode`. After POST mode=internal, GET back the mode and only fire the mode=internal_invalid workaround when the GET shows the mode did not actually flip. On firmwares where the bug is real (POST silently rejected, GET reports the old value) the workaround still runs. On firmwares where it is not, the workaround is skipped quietly.

Tests updated: `test_ambilight_mode` now asserts no follow-up workaround when the default GET fixture confirms the mode flipped, and a new `test_ambilight_mode_workaround_triggered` asserts the workaround does fire when the GET reports a stale mode.