### PR TITLE
Back off update() after consecutive ConnectionFailures

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -3,6 +3,7 @@ import httpx
 import logging
 import json
 import itertools
+import time
 from urllib.parse import quote
 from secrets import token_bytes, token_hex
 from base64 import b64decode, b64encode
@@ -69,6 +70,12 @@ HTTP_PORT = 1925
 HTTPS_PORT = 1926
 MAXIMUM_ITEMS_IN_REQUEST = 50
 IGNORED_JSON_RESPONSES = {"", "Context Service not started", "}", "<html><head><title>Ok</title></head><body>Ok</body></html>", }
+
+# update() backoff: after N consecutive ConnectionFailures, short-circuit
+# subsequent update() calls inside an exponentially growing window.
+UPDATE_BACKOFF_THRESHOLD = 3
+UPDATE_BACKOFF_INITIAL = 30.0
+UPDATE_BACKOFF_CAP = 300.0
 
 def hmac_signature(key: bytes, timestamp: str, data: str):
     """Calculate a timestamped signature."""
@@ -278,6 +285,8 @@ class PhilipsTV(object):
         self.huelamp_power: Optional[str] = None
         self.powerstate = None
         self._dead_endpoints: Set[str] = set()
+        self._consecutive_failures = 0
+        self._last_failure_at: float = 0.0
         if auth_shared_key:
             self.auth_shared_key = auth_shared_key
         else:
@@ -753,7 +762,27 @@ class PhilipsTV(object):
             )
             self._dead_endpoints.clear()
 
+    def _in_failure_backoff(self) -> bool:
+        """Return True while update() should short-circuit due to repeated failures.
+
+        After UPDATE_BACKOFF_THRESHOLD consecutive ConnectionFailures, an
+        exponentially growing window (initial UPDATE_BACKOFF_INITIAL seconds,
+        capped at UPDATE_BACKOFF_CAP) suppresses further network attempts.
+        Resets when an update() succeeds.
+        """
+        if self._consecutive_failures < UPDATE_BACKOFF_THRESHOLD:
+            return False
+        window = min(
+            UPDATE_BACKOFF_INITIAL
+            * 2 ** (self._consecutive_failures - UPDATE_BACKOFF_THRESHOLD),
+            UPDATE_BACKOFF_CAP,
+        )
+        return time.monotonic() - self._last_failure_at < window
+
     async def update(self):
+        if self._in_failure_backoff():
+            self.on = False
+            return False
         try:
             if not self.on:
                 self._reset_dead_endpoints()
@@ -780,10 +809,19 @@ class PhilipsTV(object):
             await self.getHueLampPower()
             await self.getRecordings()
             self.on = True
+            self._consecutive_failures = 0
             return True
         except ConnectionFailure as err:
             LOG.debug("TV not available: %s", repr(err))
             self.on = False
+            self._consecutive_failures += 1
+            self._last_failure_at = time.monotonic()
+            if self._consecutive_failures == UPDATE_BACKOFF_THRESHOLD:
+                LOG.warning(
+                    "TV unreachable %d times in a row; backing off polling. "
+                    "Manual power-cycle of the TV may be required.",
+                    self._consecutive_failures,
+                )
             return False
 
     def _decodeSystem(self, system) -> SystemType:

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -401,6 +401,47 @@ async def test_dead_endpoints_reset_on_off_to_on(client_mock, param: Param):
     assert "some/dead" not in client_mock._dead_endpoints
 
 
+def test_in_failure_backoff_below_threshold(client_mock):
+    """No backoff applies while consecutive failures < UPDATE_BACKOFF_THRESHOLD."""
+    client_mock._consecutive_failures = haphilipsjs.UPDATE_BACKOFF_THRESHOLD - 1
+    client_mock._last_failure_at = haphilipsjs.time.monotonic()
+    assert client_mock._in_failure_backoff() is False
+
+
+def test_in_failure_backoff_within_window(client_mock):
+    """Backoff window is active immediately after reaching the threshold."""
+    client_mock._consecutive_failures = haphilipsjs.UPDATE_BACKOFF_THRESHOLD
+    client_mock._last_failure_at = haphilipsjs.time.monotonic()
+    assert client_mock._in_failure_backoff() is True
+
+
+def test_in_failure_backoff_after_window(client_mock):
+    """Backoff window expires; update() may try again."""
+    client_mock._consecutive_failures = haphilipsjs.UPDATE_BACKOFF_THRESHOLD
+    client_mock._last_failure_at = haphilipsjs.time.monotonic() - haphilipsjs.UPDATE_BACKOFF_CAP - 10
+    assert client_mock._in_failure_backoff() is False
+
+
+async def test_update_short_circuits_during_backoff(client_mock, param: Param):
+    """While in the failure-backoff window, update() returns False without any HTTP traffic."""
+    client_mock._consecutive_failures = haphilipsjs.UPDATE_BACKOFF_THRESHOLD + 2
+    client_mock._last_failure_at = haphilipsjs.time.monotonic()
+
+    respx.calls.reset()
+    assert await client_mock.update() is False
+    assert len(respx.calls) == 0
+    assert client_mock.on is False
+
+
+async def test_update_resets_failure_counter_on_success(client_mock, param: Param):
+    """A successful update() clears _consecutive_failures so backoff is released."""
+    client_mock._consecutive_failures = haphilipsjs.UPDATE_BACKOFF_THRESHOLD + 5
+    client_mock._last_failure_at = haphilipsjs.time.monotonic() - haphilipsjs.UPDATE_BACKOFF_CAP - 10
+
+    assert await client_mock.update() is True
+    assert client_mock._consecutive_failures == 0
+
+
 async def test_ambilight_mode(client_mock, param):
     await client_mock.getSystem()
 


### PR DESCRIPTION
Some Philips API 6.x firmwares wedge their HTTPS server under sustained polling pressure (TCP/1926 still accepts connections but TLS handshake never completes). Once wedged, `update()` raises `ConnectionFailure` on every cycle and a power-cycle of the TV is the only fix.

After `UPDATE_BACKOFF_THRESHOLD` (3) consecutive `ConnectionFailure`s, subsequent `update()` calls short-circuit and return `False` without making network requests, inside an exponentially growing window (`UPDATE_BACKOFF_INITIAL` 30 s → 60 s → 120 s → cap `UPDATE_BACKOFF_CAP` 300 s). The counter resets on the next successful update.

Callers see the same `True`/`False` contract. Healthy connections are unaffected; the backoff only activates after repeated failures.

Reported in home-assistant/core#156776 ("TV not available" / wedge reports). Tested with 6 new tests covering threshold behaviour, window timing, short-circuit (no HTTP traffic), and counter reset.