### PR TITLE
Add quirk_powerstate_unreliable property

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -361,6 +361,30 @@ class PhilipsTV(object):
         return False
 
     @property
+    def quirk_powerstate_unreliable(self):
+        """Return if this tv's /powerstate endpoint is unreliable.
+
+        On affected firmware /powerstate returns "On" regardless of actual
+        TV state, including standby. Consumers that derive a power-state
+        entity from this value should treat it as a "probably on" hint
+        only and combine it with HTTP reachability and context.level1 for
+        a more honest signal.
+
+        Linux-only (Saphi / Titan OS). MSAF (Android-based) firmware does
+        report Standby / StandbyKeep correctly and is excluded.
+
+        Versions known affected:
+            - Linux on API 6.1 (TPN248E / 55OLED759/12,
+              TPN256E / 75PUS8510/12) per home-assistant/core#156776
+        """
+
+        os_type = self.os_type
+        if os_type == "Linux":
+            return True
+
+        return False
+
+    @property
     def pairing_type(self):
         if self.system:
             return (

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -175,6 +175,8 @@ async def test_basic_data(client_mock, param: Param):
             == "org.droidtv.nettv.market.MarketMainActivity-org.droidtv.nettv.market"
         )
         assert client_mock.quirk_ambilight_mode_ignored == True
+        # MSAF (Android) reports Standby/StandbyKeep correctly — quirk is Linux-only.
+        assert client_mock.quirk_powerstate_unreliable == False
         assert client_mock.os_type == "MSAF_2019_P"
 
         assert client_mock.channel_list_id == "1"
@@ -188,6 +190,7 @@ async def test_basic_data(client_mock, param: Param):
         assert client_mock.applications == {}
         assert client_mock.application_id == None
         assert client_mock.quirk_ambilight_mode_ignored == True
+        assert client_mock.quirk_powerstate_unreliable == True
         assert client_mock.os_type == "Linux"
 
         assert client_mock.channel_list_id == "all"
@@ -201,6 +204,13 @@ async def test_basic_data(client_mock, param: Param):
     assert client_mock.powerstate == POWERSTATE["powerstate"]
     assert client_mock.screenstate == SCREENSTATE["screenstate"]
     assert client_mock.huelamp_power == HUELAMPPOWER["power"]
+
+
+def test_quirk_powerstate_unreliable_false_without_system():
+    """quirk_powerstate_unreliable is False when system info has not been fetched yet."""
+    tv = haphilipsjs.PhilipsTV("127.0.0.1", api_version=6)
+    assert tv.system is None
+    assert tv.quirk_powerstate_unreliable is False
 
 
 async def test_current_channel_none(client_mock, param):


### PR DESCRIPTION
On Philips API 6.x firmware the `/powerstate` endpoint always returns `"On"` regardless of actual TV state, including standby. A `media_player.state` derived purely from `getPowerState()` will therefore report ON whenever the TV's HTTPS server is reachable, never distinguishing power-on from standby.

This patch adds a `quirk_powerstate_unreliable` property using the same firmware-family detection as `quirk_ambilight_mode_ignored` (MSAF_*, Linux). Consumers can read it to gate alternative state-derivation logic (combine reachability + `context.level1` instead of trusting `/powerstate`).

Verified on TPN248E / 55OLED759/12 and TPN256E / 75PUS8510/12 in home-assistant/core#156776.

A consumer-side PR against `home-assistant/core`'s `philips_js` integration is planned to follow, so this property has an immediate use.