### PR TITLE
Turn ambilight off via cached pixels on quirked firmware

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -1385,10 +1385,16 @@ class PhilipsTV(object):
                 self.ambilight_mode_set = None
                 # This firmware ignores an "OFF" style; the LEDs keep
                 # rendering. Darken them by writing zero pixels in expert mode.
+                # Write the zeros both before and after switching to expert:
+                # the pre-expert write lets renderer-driven firmwares (Android)
+                # darken without flashing the stale buffer when expert engages,
+                # while the post-expert write is what actually lands on firmwares
+                # that only honour cached writes while already in expert (Saphi).
                 if (
                     config.get("styleName") == "OFF"
                     and self.ambilight_cached_off is not None
                 ):
+                    await self.setAmbilightCached(self.ambilight_cached_off)
                     await self.setAmbilightMode("expert")
                     await self.setAmbilightCached(self.ambilight_cached_off)
 

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -401,7 +401,12 @@ class PhilipsTV(object):
         It also ignores ambilight off: a POST to ambilight/currentconfiguration
         with ``styleName`` ``"OFF"`` returns OK but the LEDs stay lit, so
         setAmbilightCurrentConfiguration darkens them by writing zero cached
-        pixels in expert mode when the configuration is set off.
+        pixels around a switch to expert mode when the configuration is set
+        off. The zeros are written both before and after the switch: the
+        pre-expert write lets renderer-driven firmwares (Android) darken
+        without flashing the stale buffer when expert engages, while the
+        post-expert write is what actually lands on firmwares that only honour
+        cached writes while already in expert (Saphi).
 
         Versions known affected:
             - Android - 9.0.0
@@ -1383,13 +1388,6 @@ class PhilipsTV(object):
 
             if self.quirk_ambilight_mode_ignored:
                 self.ambilight_mode_set = None
-                # This firmware ignores an "OFF" style; the LEDs keep
-                # rendering. Darken them by writing zero pixels in expert mode.
-                # Write the zeros both before and after switching to expert:
-                # the pre-expert write lets renderer-driven firmwares (Android)
-                # darken without flashing the stale buffer when expert engages,
-                # while the post-expert write is what actually lands on firmwares
-                # that only honour cached writes while already in expert (Saphi).
                 if (
                     config.get("styleName") == "OFF"
                     and self.ambilight_cached_off is not None

--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -261,6 +261,29 @@ def _ambilight_styles_menu_family(os_type: Optional[str]) -> Optional[str]:
     return None
 
 
+def _build_ambilight_off(
+    cached: Optional[AmbilightLayersType],
+) -> Optional[AmbilightLayersType]:
+    """Return the cached pixel layout with every channel zeroed, or None.
+
+    Empty sides are skipped; the TV rejects a payload that includes them.
+    """
+    if not cached:
+        return None
+    result = {
+        layer: zeroed
+        for layer, sides in cached.items()
+        if (
+            zeroed := {
+                side: {index: {"r": 0, "g": 0, "b": 0} for index in pixels}
+                for side, pixels in sides.items()
+                if pixels
+            }
+        )
+    }
+    return cast(Optional[AmbilightLayersType], result or None)
+
+
 class PhilipsTV(object):
 
     channels: ChannelsType
@@ -302,6 +325,7 @@ class PhilipsTV(object):
         self.ambilight_mode_set = None
         self.ambilight_mode_raw: Optional[str] = None
         self.ambilight_cached: Optional[AmbilightLayersType] = None
+        self.ambilight_cached_off: Optional[AmbilightLayersType] = None
         self.ambilight_measured: Optional[AmbilightLayersType] = None
         self.ambilight_processed: Optional[AmbilightLayersType] = None
         self.ambilight_power_raw: Optional[Dict] = None
@@ -373,6 +397,11 @@ class PhilipsTV(object):
 
         It will also not report a correct ambilight mode after being
         changed by call. So we need to remember last set mode.
+
+        It also ignores ambilight off: a POST to ambilight/currentconfiguration
+        with ``styleName`` ``"OFF"`` returns OK but the LEDs stay lit, so
+        setAmbilightCurrentConfiguration darkens them by writing zero cached
+        pixels in expert mode when the configuration is set off.
 
         Versions known affected:
             - Android - 9.0.0
@@ -1238,8 +1267,10 @@ class PhilipsTV(object):
         r = await self.getReq("ambilight/cached")
         if r:
             self.ambilight_cached = r
+            self.ambilight_cached_off = _build_ambilight_off(r)
         else:
             self.ambilight_cached = None
+            self.ambilight_cached_off = None
         return r
 
     async def getAmbilightPower(self):
@@ -1352,6 +1383,14 @@ class PhilipsTV(object):
 
             if self.quirk_ambilight_mode_ignored:
                 self.ambilight_mode_set = None
+                # This firmware ignores an "OFF" style; the LEDs keep
+                # rendering. Darken them by writing zero pixels in expert mode.
+                if (
+                    config.get("styleName") == "OFF"
+                    and self.ambilight_cached_off is not None
+                ):
+                    await self.setAmbilightMode("expert")
+                    await self.setAmbilightCached(self.ambilight_cached_off)
 
             return True
 

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -473,6 +473,71 @@ async def test_ambilight_power(client_mock, param):
 
     await client_mock.setAmbilightPower("Off")
     assert json.loads(route.calls[1].request.content) == {"power": "Off"}
+    assert client_mock.ambilight_power == "Off"
+
+
+async def test_ambilight_off_via_currentconfiguration(client_mock, param):
+    """Quirked firmware ignores the OFF style, so setting the configuration to
+    OFF darkens the LEDs by writing zero cached pixels in expert mode."""
+    await client_mock.getSystem()
+    if not client_mock.quirk_ambilight_mode_ignored:
+        pytest.skip("Workaround only runs when quirk_ambilight_mode_ignored is True")
+
+    await client_mock.getAmbilightCached()
+    assert client_mock.ambilight_cached_off is not None
+
+    config_route = respx.post(
+        f"{param.base}/ambilight/currentconfiguration"
+    ).respond(json={})
+    mode_route = respx.post(f"{param.base}/ambilight/mode").respond(json={})
+    cached_route = respx.post(f"{param.base}/ambilight/cached").respond(json={})
+
+    await client_mock.setAmbilightCurrentConfiguration(
+        {"styleName": "OFF", "isExpert": False, "menuSetting": ""}
+    )
+
+    # The OFF configuration is posted as usual...
+    assert json.loads(config_route.calls.last.request.content)["styleName"] == "OFF"
+    # ...then the quirk switches to expert mode...
+    assert json.loads(mode_route.calls.last.request.content) == {"current": "expert"}
+    # ...and writes the zeroed cached layout.
+    cached_body = json.loads(cached_route.calls.last.request.content)
+    assert cached_body == client_mock.ambilight_cached_off
+    assert all(
+        px == {"r": 0, "g": 0, "b": 0}
+        for sides in cached_body.values()
+        for pixels in sides.values()
+        for px in pixels.values()
+    )
+
+
+def test_build_ambilight_off_skips_empty_sides_all_layers():
+    """Empty sides are dropped, every remaining pixel zeroed, across all layers."""
+    cached = {
+        "layer1": {
+            "left": {"0": {"r": 5, "g": 6, "b": 7}},
+            "top": {},
+            "right": {"0": {"r": 1, "g": 2, "b": 3}, "1": {"r": 9, "g": 9, "b": 9}},
+            "bottom": {},
+        },
+        "layer2": {
+            "top": {"0": {"r": 4, "g": 4, "b": 4}},
+        },
+    }
+    assert haphilipsjs._build_ambilight_off(cached) == {
+        "layer1": {
+            "left": {"0": {"r": 0, "g": 0, "b": 0}},
+            "right": {"0": {"r": 0, "g": 0, "b": 0}, "1": {"r": 0, "g": 0, "b": 0}},
+        },
+        "layer2": {"top": {"0": {"r": 0, "g": 0, "b": 0}}},
+    }
+
+
+def test_build_ambilight_off_none_without_usable_layout():
+    """No cached data, or only empty sides, yields None."""
+    assert haphilipsjs._build_ambilight_off(None) is None
+    assert haphilipsjs._build_ambilight_off({}) is None
+    assert haphilipsjs._build_ambilight_off({"layer1": {"top": {}, "bottom": {}}}) is None
 
 
 def test_ambilight_styles_menu_family():

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -477,14 +477,8 @@ async def test_ambilight_power(client_mock, param):
 
 
 async def test_ambilight_off_via_currentconfiguration(client_mock, param):
-    """Quirked firmware ignores the OFF style, so setting the configuration to
-    OFF darkens the LEDs by writing zero cached pixels around an expert switch.
-
-    The zeros are written both before and after switching to expert: the
-    pre-expert write lets renderer-driven firmwares (Android) darken without
-    flashing the stale buffer, and the post-expert write is what lands on
-    firmwares that only honour cached writes while already in expert (Saphi).
-    """
+    """Setting the configuration to OFF on quirked firmware darkens the LEDs by
+    writing zero cached pixels both before and after a switch to expert mode."""
     await client_mock.getSystem()
     if not client_mock.quirk_ambilight_mode_ignored:
         pytest.skip("Workaround only runs when quirk_ambilight_mode_ignored is True")

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -478,7 +478,13 @@ async def test_ambilight_power(client_mock, param):
 
 async def test_ambilight_off_via_currentconfiguration(client_mock, param):
     """Quirked firmware ignores the OFF style, so setting the configuration to
-    OFF darkens the LEDs by writing zero cached pixels in expert mode."""
+    OFF darkens the LEDs by writing zero cached pixels around an expert switch.
+
+    The zeros are written both before and after switching to expert: the
+    pre-expert write lets renderer-driven firmwares (Android) darken without
+    flashing the stale buffer, and the post-expert write is what lands on
+    firmwares that only honour cached writes while already in expert (Saphi).
+    """
     await client_mock.getSystem()
     if not client_mock.quirk_ambilight_mode_ignored:
         pytest.skip("Workaround only runs when quirk_ambilight_mode_ignored is True")
@@ -498,17 +504,33 @@ async def test_ambilight_off_via_currentconfiguration(client_mock, param):
 
     # The OFF configuration is posted as usual...
     assert json.loads(config_route.calls.last.request.content)["styleName"] == "OFF"
-    # ...then the quirk switches to expert mode...
+    # ...the quirk switches to expert mode...
     assert json.loads(mode_route.calls.last.request.content) == {"current": "expert"}
-    # ...and writes the zeroed cached layout.
-    cached_body = json.loads(cached_route.calls.last.request.content)
-    assert cached_body == client_mock.ambilight_cached_off
-    assert all(
-        px == {"r": 0, "g": 0, "b": 0}
-        for sides in cached_body.values()
-        for pixels in sides.values()
-        for px in pixels.values()
-    )
+    # ...and brackets that switch with two zeroed cached writes.
+    assert cached_route.call_count == 2
+    # Order: configuration -> cached -> mode -> cached.
+    quirk_paths = [
+        call.request.url.path
+        for call in respx.calls
+        if call.request.url.path.startswith("/6/ambilight/")
+        and call.request.method == "POST"
+    ]
+    assert quirk_paths == [
+        "/6/ambilight/currentconfiguration",
+        "/6/ambilight/cached",
+        "/6/ambilight/mode",
+        "/6/ambilight/cached",
+    ]
+    # Both cached writes carry the zeroed layout.
+    for cached_call in cached_route.calls:
+        cached_body = json.loads(cached_call.request.content)
+        assert cached_body == client_mock.ambilight_cached_off
+        assert all(
+            px == {"r": 0, "g": 0, "b": 0}
+            for sides in cached_body.values()
+            for pixels in sides.values()
+            for px in pixels.values()
+        )
 
 
 def test_build_ambilight_off_skips_empty_sides_all_layers():


### PR DESCRIPTION
On firmware where `quirk_ambilight_mode_ignored` is set, `POST /ambilight/power {"power": "Off"}` returns 200 but leaves the LEDs lit. `setAmbilightPower("Off")` now mirrors what the `api_version == 1` path already does (paint zeros), using the API 6 sequence: unstick any sticky lounge state with a benign `currentconfiguration`, switch to expert mode, then write an all-zero cached layer built from the reported pixel layout (empty sides skipped so the TV does not reject the payload).

The `"On"` direction and non-quirked firmware are unchanged. Quirk handling stays inside the library, so the integration just calls `setAmbilightPower` and never branches on the quirk itself.

This is the library-side home for the ambilight-off fix that was attempted integration-side in home-assistant/core#172564. Once this lands and releases, the core integration `async_turn_off` can simply call `setAmbilightPower("Off")`.

Tested: updated `test_ambilight_power` to assert the cached path on quirked firmware, plus unit tests for the zero-layer builder. Full suite passes.