### PR TITLE
Extend supportedstyles menuSettings fallback to Linux firmware

### DIFF
--- a/haphilipsjs/__init__.py
+++ b/haphilipsjs/__init__.py
@@ -44,6 +44,10 @@ from .typing import (
     ApplicationType,
 )
 from .auth import CachedDigestAuth
+from .data.v6 import (
+    AMBILIGHT_SUPPORTED_STYLES_EXTENDED_ANDROID,
+    AMBILIGHT_SUPPORTED_STYLES_EXTENDED_SAPHI,
+)
 
 LOG = logging.getLogger(__name__)
 TIMEOUT = 20.0
@@ -226,6 +230,37 @@ def handle_httpx_exceptions(f):
     return wrapper
 
 
+_AMBILIGHT_STYLE_MENU_FALLBACK = {
+    "MSAF": {
+        "FOLLOW_VIDEO": AMBILIGHT_SUPPORTED_STYLES_EXTENDED_ANDROID["FOLLOW_VIDEO"]["menuSettings"],
+        "FOLLOW_AUDIO": AMBILIGHT_SUPPORTED_STYLES_EXTENDED_ANDROID["FOLLOW_AUDIO"]["menuSettings"],
+        "FOLLOW_COLOR": AMBILIGHT_SUPPORTED_STYLES_EXTENDED_ANDROID["Lounge light"]["menuSettings"],
+    },
+    "Linux": {
+        "FOLLOW_VIDEO": AMBILIGHT_SUPPORTED_STYLES_EXTENDED_SAPHI["FOLLOW_VIDEO"]["menuSettings"],
+        "FOLLOW_AUDIO": AMBILIGHT_SUPPORTED_STYLES_EXTENDED_SAPHI["FOLLOW_AUDIO"]["menuSettings"],
+        "FOLLOW_COLOR": AMBILIGHT_SUPPORTED_STYLES_EXTENDED_SAPHI["Lounge light"]["menuSettings"],
+    },
+}
+
+
+def _ambilight_styles_menu_family(os_type: Optional[str]) -> Optional[str]:
+    """Map a TV os_type to its ambilight menuSettings fallback family, or None.
+
+    Both the MSAF (Android) and Linux (Saphi / Titan OS) firmware families
+    omit menuSettings from /ambilight/supportedstyles even though the named
+    presets are user-selectable. The preset catalogs differ between the two
+    families, so each gets its own value set.
+    """
+    if os_type is None:
+        return None
+    if os_type.startswith("MSAF_"):
+        return "MSAF"
+    if os_type == "Linux":
+        return "Linux"
+    return None
+
+
 class PhilipsTV(object):
 
     channels: ChannelsType
@@ -307,10 +342,7 @@ class PhilipsTV(object):
 
     @property
     def quirk_ambilight_styles_menuitems(self):
-        if self.system:
-            return self.system.get("os_type", "").startswith("MSAF_")
-        else:
-            return False
+        return _ambilight_styles_menu_family(self.os_type) is not None
 
     @property
     def os_type(self):
@@ -1269,25 +1301,18 @@ class PhilipsTV(object):
                 }
 
                 if self.quirk_ambilight_styles_menuitems:
+                    family = _ambilight_styles_menu_family(self.os_type)
+                    menu = _AMBILIGHT_STYLE_MENU_FALLBACK[family]
+
                     style = self.ambilight_styles.setdefault(
                         "FOLLOW_VIDEO", {"styleName": "FOLLOW_VIDEO"}
                     )
-                    style["menuSettings"] = [
-                        "STANDARD",
-                        "VIVID",
-                        "IMMERSIVE",
-                        "NATURAL",
-                        "GAME",
-                    ]
+                    style["menuSettings"] = menu["FOLLOW_VIDEO"]
 
                     style = self.ambilight_styles.setdefault(
                         "FOLLOW_AUDIO", {"styleName": "FOLLOW_AUDIO"}
                     )
-                    style["menuSettings"] = [
-                        "ENERGY_ADAPTIVE_BRIGHTNESS",
-                        "VU_METER",
-                        "RANDOM_PIXEL_FLASH",
-                    ]
+                    style["menuSettings"] = menu["FOLLOW_AUDIO"]
 
                     if "Lounge light" in self.ambilight_styles:
                         style = self.ambilight_styles["Lounge light"]
@@ -1297,13 +1322,7 @@ class PhilipsTV(object):
                         style = self.ambilight_styles.setdefault(
                             "Lounge light", {"styleName": "Lounge light"}
                         )
-                    style["menuSettings"] = [
-                        "HOT_LAVA",
-                        "DEEP_WATER",
-                        "FRESH_NATURE",
-                        "ISF",
-                        "CUSTOM_COLOR",
-                    ]
+                    style["menuSettings"] = menu["FOLLOW_COLOR"]
             else:
                 self.ambilight_styles = {}
             return r

--- a/haphilipsjs/data/v6.py
+++ b/haphilipsjs/data/v6.py
@@ -608,11 +608,41 @@ AMBILIGHT_SUPPORTED_STYLES_EXTENDED_SAPHI: Dict[str, AmbilightSupportedStyleType
             "PARTY",
         ],
         "maxTuning": 2,
+        "menuSettings": [
+            "ENERGY_ADAPTIVE_BRIGHTNESS",
+            "ENERGY_ADAPTIVE_COLORS",
+            "VU_METER",
+            "SPECTRUM_ANALYZER",
+            "KNIGHT_RIDER_CLOCKWISE",
+            "KNIGHT_RIDER_ALTERNATING",
+            "RANDOM_PIXEL_FLASH",
+            "STROBE",
+            "PARTY",
+        ],
     },
     "Lounge light": {
         "styleName": "Lounge light",
         "algorithms": ["MANUAL_HUE", "AUTOMATIC_HUE"],
         "maxSpeed": 255,
+        "menuSettings": [
+            "PTA_LOUNGE",
+            "DEEP_WATER",
+            "HOT_LAVA",
+            "FRESH_NATURE",
+            "ISF_BLUE",
+        ],
+    },
+    "FOLLOW_VIDEO": {
+        "styleName": "FOLLOW_VIDEO",
+        "menuSettings": [
+            "STANDARD",
+            "NATURAL",
+            "VIVID",
+            "CINEMA",
+            "GAME",
+            "SPORTS",
+            "COMFORT",
+        ],
     },
 }
 

--- a/tests/test_v6.py
+++ b/tests/test_v6.py
@@ -475,6 +475,15 @@ async def test_ambilight_power(client_mock, param):
     assert json.loads(route.calls[1].request.content) == {"power": "Off"}
 
 
+def test_ambilight_styles_menu_family():
+    """os_type maps to the correct menuSettings fallback family."""
+    assert haphilipsjs._ambilight_styles_menu_family("MSAF_2019_P") == "MSAF"
+    assert haphilipsjs._ambilight_styles_menu_family("Linux") == "Linux"
+    assert haphilipsjs._ambilight_styles_menu_family(None) is None
+    assert haphilipsjs._ambilight_styles_menu_family("") is None
+    assert haphilipsjs._ambilight_styles_menu_family("Tizen") is None
+
+
 async def test_ambilight_topology(client_mock):
     assert await client_mock.getAmbilightTopology() == AMBILIGHT["topology"]
 


### PR DESCRIPTION
getAmbilightSupportedStyles already injects fallback menuSettings on MSAF (Android) firmware, which omits them from /ambilight/supportedstyles even though the presets are user-selectable. Linux (Saphi / Titan OS) firmware has the same gap but a different preset catalog (e.g. CINEMA / SPORTS / COMFORT for video and PTA_LOUNGE / ISF_BLUE for colour rather than the MSAF values).

This moves the per-style values into a family-keyed table, widens quirk_ambilight_styles_menuitems to cover both families, and selects the value set by os_type. MSAF values and behaviour are unchanged. The quirk now resolves os_type through the os_type property, so it also works for Saphi, which reports os_type under featuring.systemfeatures rather than at the system root (the previous root-only lookup silently missed it).

The Linux preset values are verified on a TPN248E / 55OLED759/12 (home-assistant/core#156776); other Linux models may expose a slightly different catalog, so the lists are easy to adjust.

Tested: the existing supportedstyles test now covers the Linux fallback via the saphi fixture, MSAF output is byte-identical, plus a small unit test for the family mapping. Full suite passes.